### PR TITLE
Allow HTTPS URLs for WP backend during config

### DIFF
--- a/nxtwp
+++ b/nxtwp
@@ -64,7 +64,7 @@ function start_env_frontend() {
 
 # Check URL
 function check_url_input() {
-    regex='(http?)://[-A-Za-z0-9:0-9]'
+    regex='(https?)://[-A-Za-z0-9:0-9]'
     user_input=$1
 
     if ! [[ $user_input =~ $regex ]]


### PR DESCRIPTION
I was trying to use an https:// URL for my WP backend and I kept getting that "URL Is not valid" error.

Modified the regex to make the `s` in `https` optional, rather than the `p` in `http`. :)