### PR TITLE
Minor Seo Bug #68 - noindex / nofollow

### DIFF
--- a/frontend/src/components/seo/index.js
+++ b/frontend/src/components/seo/index.js
@@ -33,8 +33,8 @@ const Seo = ( {seo, uri} ) => {
 			title={title}
 			description={opengraphDescription || metaDesc}
 			canonical={opengraphUrl}
-			noindex={metaRobotsNoindex === "noindex"}
-			nofollow={metaRobotsNofollow === "nofollow"}
+			noindex={"noindex" === metaRobotsNoindex }
+			nofollow={"nofollow" === metaRobotsNofollow}
 			openGraph={{
 				type: 'website',
 				locale: 'en_US',

--- a/frontend/src/components/seo/index.js
+++ b/frontend/src/components/seo/index.js
@@ -33,8 +33,8 @@ const Seo = ( {seo, uri} ) => {
 			title={title}
 			description={opengraphDescription || metaDesc}
 			canonical={opengraphUrl}
-			noindex={metaRobotsNoindex}
-			nofollow={metaRobotsNofollow}
+			noindex={metaRobotsNoindex === "noindex"}
+			nofollow={metaRobotsNofollow === "nofollow"}
 			openGraph={{
 				type: 'website',
 				locale: 'en_US',


### PR DESCRIPTION
Hello Imranhsayed, thank you for the repo and lessons.

https://github.com/imranhsayed/nextjs-headless-wordpress/blob/main/frontend/src/components/seo/index.js

The fields have the following values:

metaRobotsNoindex, // index | noindex
metaRobotsNofollow, // follow | nofollow

So in the component, it should be

    noindex={metaRobotsNoindex === "noindex"}
    nofollow={metaRobotsNofollow === "nofollow"}

issue: https://github.com/imranhsayed/nextjs-headless-wordpress/issues/68


