### PR TITLE
Update docker-compose.yml

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -9,8 +9,6 @@ services:
 
   mysql:
     image: mysql:5.7
-    volumes:
-      - mysql_data:/var/lib/mysql
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: root
@@ -37,7 +35,7 @@ services:
       - mysql
       - composer
     build: ./php
-    image: wordpress_image
+    image: wordpress:latest
     ports:
       - "8020:80"
     restart: always


### PR DESCRIPTION
Line 20 was already declared on line 12, so I removed line 12. Additionally, the image name for WordPress was incorrect, resulting in a 'pull request denial' during integration. I corrected this by using the official wordpress:latest image, which resolved the issue.